### PR TITLE
squelch link script output

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: a87a762511d912d2aaec5093a845f4163fc9ff789c8ad7bd004d42714d424707
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,7 +1,7 @@
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable nb_anacondacloud --py --sys-prefix  || EXIT /B 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable nb_anacondacloud --py --sys-prefix  > NUL 2>&1 || EXIT /B 1
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
-"%PREFIX%\Scripts\jupyter-serverextension.exe" enable --py nb_anacondacloud --sys-prefix  || EXIT /B 1
+"%PREFIX%\Scripts\jupyter-serverextension.exe" enable --py nb_anacondacloud --sys-prefix  > NUL 2>&1 || EXIT /B 1
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
 if errorlevel 1 exit 1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,7 +1,5 @@
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable nb_anacondacloud --py --sys-prefix  > NUL 2>&1 || EXIT /B 1
-IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
-
-"%PREFIX%\Scripts\jupyter-serverextension.exe" enable --py nb_anacondacloud --sys-prefix  > NUL 2>&1 || EXIT /B 1
-IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
-
-if errorlevel 1 exit 1
+@echo off
+1>>"%PREFIX%\.messages.txt" 2>&1 (
+  "%PREFIX%\Scripts\jupyter-nbextension.exe" enable nb_anacondacloud --py --sys-prefix
+  "%PREFIX%\Scripts\jupyter-serverextension.exe" enable --py nb_anacondacloud --sys-prefix
+)

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,2 +1,4 @@
-"${PREFIX}/bin/jupyter-nbextension" enable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1
-"${PREFIX}/bin/jupyter-serverextension" enable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1
+{
+  "${PREFIX}/bin/jupyter-nbextension" enable nb_anacondacloud --py --sys-prefix
+  "${PREFIX}/bin/jupyter-serverextension" enable nb_anacondacloud --py --sys-prefix
+} >>"$PREFIX/.messages.txt" 2>&1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,2 +1,2 @@
-"${PREFIX}/bin/jupyter-nbextension" enable nb_anacondacloud --py --sys-prefix
-"${PREFIX}/bin/jupyter-serverextension" enable nb_anacondacloud --py --sys-prefix
+"${PREFIX}/bin/jupyter-nbextension" enable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-serverextension" enable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,2 +1,2 @@
-"%PREFIX%\Scripts\jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix
-"%PREFIX%\Scripts\jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix
+"%PREFIX%\Scripts\jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix > NUL 2>&1
+"%PREFIX%\Scripts\jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix > NUL 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,2 +1,5 @@
-"%PREFIX%\Scripts\jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix > NUL 2>&1
-"%PREFIX%\Scripts\jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix > NUL 2>&1
+@echo off
+1>>"%PREFIX%\.messages.txt" 2>&1 (
+  "%PREFIX%\Scripts\jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix
+  "%PREFIX%\Scripts\jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix
+)

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,2 +1,2 @@
-"${PREFIX}/bin/jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix
-"${PREFIX}/bin/jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix
+"${PREFIX}/bin/jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,2 +1,4 @@
-"${PREFIX}/bin/jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1
-"${PREFIX}/bin/jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix > /dev/null 2>&1
+{
+  "${PREFIX}/bin/jupyter-nbextension" disable nb_anacondacloud --py --sys-prefix
+  "${PREFIX}/bin/jupyter-serverextension" disable nb_anacondacloud --py --sys-prefix
+} >>"$PREFIX/.messages.txt" 2>&1


### PR DESCRIPTION
Nobody likes the output from the post-link scripts from `jupyter nbextension enable`. This redirects any such output.

I'll be doing these for the other extensions as well :)
