### PR TITLE
Add pyyaml to dependencies.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,12 +23,14 @@ requirements:
     - setuptools
     - notebook >=4.3.1
     - anaconda-client
+    - pyyaml
 
   run:
     - python
     - notebook >=4.3.1
     - nb_conda_kernels >=2.0.0
     - anaconda-client
+    - pyyaml
 
 test:
   imports:


### PR DESCRIPTION
pyyaml is required to build and run `nb_anacondacloud`. 